### PR TITLE
fix: nack message when application controller throws an error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gojob/nest-cloud-pub-sub-transport",
   "description": "A Custom Transport strategy of the NestJS microservices pattern for Cloud Pub/Sub.",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "repository": "git@github.com:gojob-1337/nest-cloud-pub-sub-transport.git",
   "author": "VinceOPS <vincent@gojob.com>",
   "license": "MIT",

--- a/server/cloud-server-pub-sub.ts
+++ b/server/cloud-server-pub-sub.ts
@@ -241,6 +241,9 @@ export class CloudServerPubSub extends Server implements CustomTransportStrategy
     // ackAfterHandler has been enabled: execute the handler, then, eventually ACK the message
     try {
       const observableResult = await handler(data);
+      if (observableResult) {
+        await observableResult.toPromise();
+      }
       message.ack();
       return observableResult;
     } catch (error) {


### PR DESCRIPTION
## Rationale

When testing this module in our app, we have experienced that the messages are **not** `nacked` when our NestJS controller throws an error 😱

## Root cause

After investigation, I have found this is because the `handler` **always** resolves a rxjs `Observable`, even when an exception is thrown within the resolved application controller. This observable needs to be mapped to a promise, and we need to await on it in order for the application error to be raised, and the message to be `nacked` properly.

## Fix

This MR fixes this issue, update an existing test to properly simulate the "real" behavior when `acking` the message, and adds a test case to simulate the application error scenario. (with a quick refacto to mutualize the testing logic with the existing handler error test case)